### PR TITLE
Add ACF Options page and Testimonials post type

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -15,6 +15,7 @@ class MentorWorksSite extends TimberSite {
 		add_theme_support( 'post-formats' );
 		add_theme_support( 'post-thumbnails' );
 		add_theme_support( 'menus' );
+		add_advanced_custom_fields_options_page();
 		add_filter( 'timber_context', array( $this, 'add_to_context' ) );
 		add_filter( 'get_twig', array( $this, 'add_to_twig' ) );
 		add_action( 'init', array( $this, 'register_post_types' ) );
@@ -28,6 +29,16 @@ class MentorWorksSite extends TimberSite {
 	      'labels' => array(
 	        'name' => __('FAQs'),
 	        'singular_name' => __('FAQ')
+	      ),
+	      'public' => false,
+	      'show_ui' => true
+	    )
+	  );
+	  register_post_type('testimonials',
+	    array(
+	      'labels' => array(
+	        'name' => __('Testimonials'),
+	        'singular_name' => __('Testimonial')
 	      ),
 	      'public' => false,
 	      'show_ui' => true


### PR DESCRIPTION
Quick PR to add a "Testimonials" post type in WP and enable support for the ACF options page. Staging needs to be updated after this is merged in