### PR TITLE
Enable options page context and add more components

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -62,6 +62,7 @@ class MentorWorksSite extends TimberSite {
 	function add_to_context( $context ) {
 		$context['header_menu'] = new TimberMenu('Header Menu');
 		$context['footer_menu'] = new TimberMenu('Footer Menu');
+		$context['options'] = get_fields('option');
 		$context['site'] = $this;
 		return $context;
 	}

--- a/src/templates/shared/contact-form.twig
+++ b/src/templates/shared/contact-form.twig
@@ -1,0 +1,1 @@
+{{ function('do_shortcode', component.mw_contact_form.mw_contact_form_id) }}


### PR DESCRIPTION
- Adds options page from ACF to global Timber context
- Adds a calculator component in ACF. The template is empty because we're not going to use ACF fields, but just the general component
- Adds a contact form component, which takes a Contact Form 7 ID from WP and outputs the rendered HTML